### PR TITLE
Enable scrollable drag-and-drop reordering with dnd-kit

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,9 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
+    "@dnd-kit/core": "^6.1.0",
+    "@dnd-kit/sortable": "^9.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@mui/icons-material": "^7.3.5",
     "@mui/material": "^7.1.1",
     "@reduxjs/toolkit": "^2.8.2",

--- a/src/renderer/src/components/ScenesScreen.tsx
+++ b/src/renderer/src/components/ScenesScreen.tsx
@@ -11,6 +11,18 @@ import IconButton from "@mui/material/IconButton";
 import SwapVertIcon from "@mui/icons-material/SwapVert";
 import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
 import { motion, AnimatePresence } from "framer-motion";
+import {
+  DndContext,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  DragStartEvent,
+  DragOverEvent,
+  DragEndEvent,
+} from "@dnd-kit/core";
+import { SortableContext, rectSortingStrategy, useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 
 import { AppDispatch, RootState } from "../store/store";
 import { useTranslation } from "../useTranslation";
@@ -68,6 +80,13 @@ export const ScenesScreen: React.FC = () => {
   const [reorderList, setReorderList] = useState<string[]>([]);
   const [draggingId, setDraggingId] = useState<string | null>(null);
   const [dragOverId, setDragOverId] = useState<string | null>(null);
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 6,
+      },
+    })
+  );
 
   const orderedScenes: SceneSummary[] = useMemo(() => {
     const idToScene = new Map<string, SceneSummary>();
@@ -133,6 +152,7 @@ export const ScenesScreen: React.FC = () => {
     });
   }, [orderedScenes, isReorderMode]);
 
+  // ドラッグ中でもホイールスクロールできるようにする
   useEffect(() => {
     if (!draggingId) return;
 
@@ -147,47 +167,31 @@ export const ScenesScreen: React.FC = () => {
     };
   }, [draggingId]);
 
-  const moveIdInList = (list: string[], fromId: string, toId: string) => {
-    if (fromId === toId) return list;
-    const fromIndex = list.indexOf(fromId);
-    const toIndex = list.indexOf(toId);
-    if (fromIndex === -1 || toIndex === -1) return list;
-    const next = [...list];
-    next.splice(fromIndex, 1);
-    next.splice(toIndex, 0, fromId);
-    return next;
-  };
-
-  const handleReorder = (visibleOrder: string[]) => {
-    setReorderList(visibleOrder);
-  };
-
-  const handleDragStart = (id: string) => (event: React.DragEvent<HTMLDivElement>) => {
-    setDraggingId(id);
+  const handleDragStart = (event: DragStartEvent) => {
+    setDraggingId(event.active.id as string);
     setDragOverId(null);
-    event.dataTransfer.effectAllowed = "move";
   };
 
-  const handleDragOver = (overId: string) => (event: React.DragEvent<HTMLDivElement>) => {
-    event.preventDefault();
-    if (!draggingId || draggingId === overId) return;
+  const handleDragOver = (event: DragOverEvent) => {
+    const overId = event.over?.id as string | undefined;
+    if (!overId) return;
     setDragOverId(overId);
   };
 
-  const handleDragLeave = () => {
-    setDragOverId(null);
-  };
-
-  const handleDrop = (overId: string) => (event: React.DragEvent<HTMLDivElement>) => {
-    event.preventDefault();
-    if (draggingId && overId && draggingId !== overId) {
-      setReorderList((prev) => moveIdInList(prev, draggingId, overId));
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (over && active.id !== over.id) {
+      setReorderList((prev) => {
+        const oldIndex = prev.indexOf(active.id as string);
+        const newIndex = prev.indexOf(over.id as string);
+        if (oldIndex === -1 || newIndex === -1) return prev;
+        const next = [...prev];
+        next.splice(oldIndex, 1);
+        next.splice(newIndex, 0, active.id as string);
+        return next;
+      });
     }
-    setDraggingId(null);
-    setDragOverId(null);
-  };
 
-  const handleDragEnd = () => {
     setDraggingId(null);
     setDragOverId(null);
   };
@@ -214,6 +218,10 @@ export const ScenesScreen: React.FC = () => {
       startReorder();
     }
   };
+
+  const sortableItems = isReorderMode
+    ? reorderList.map((sceneId) => sceneMap.get(sceneId)).filter((scene): scene is SceneSummary => !!scene)
+    : orderedScenes;
 
   const handleRefresh = () => {
     if (isTokenValid && apiToken) {
@@ -294,127 +302,48 @@ export const ScenesScreen: React.FC = () => {
             <Alert severity="info">{t("No scenes found. Create a manual scene in the SwitchBot app.")}</Alert>
           )}
           <motion.div variants={containerVariants} initial="hidden" animate="visible">
-            <Box
-              sx={{
-                display: "grid",
-                gridTemplateColumns: "repeat(auto-fill, 160px)",
-                gap: 1.5,
-                justifyContent: "center",
-              }}
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragStart={isReorderMode ? handleDragStart : undefined}
+              onDragOver={isReorderMode ? handleDragOver : undefined}
+              onDragEnd={isReorderMode ? handleDragEnd : undefined}
             >
-              <AnimatePresence>
-                {(isReorderMode
-                  ? reorderList
-                      .map((sceneId) => sceneMap.get(sceneId))
-                      .filter((scene): scene is SceneSummary => !!scene)
-                  : orderedScenes
-                ).map((scene) => {
-                  const isExecuting = !!executingById[scene.sceneId];
-                  const sceneError = executionErrorById[scene.sceneId];
-                  return (
-                    <motion.div key={scene.sceneId} variants={itemVariants} layout>
-                      <Box
-                        sx={{
-                          position: "relative",
-                          opacity: draggingId === scene.sceneId ? 0.5 : 1,
-                          transition: "opacity 0.2s ease",
-                          outline: dragOverId === scene.sceneId ? "2px solid" : "none",
-                          outlineColor: "primary.main",
-                          outlineOffset: "2px",
-                          borderRadius: 2,
-                        }}
-                        draggable={isReorderMode}
-                        onDragStart={isReorderMode ? handleDragStart(scene.sceneId) : undefined}
-                        onDragOver={isReorderMode ? handleDragOver(scene.sceneId) : undefined}
-                        onDragLeave={isReorderMode ? handleDragLeave : undefined}
-                        onDrop={isReorderMode ? handleDrop(scene.sceneId) : undefined}
-                        onDragEnd={isReorderMode ? handleDragEnd : undefined}
-                      >
-                        {isReorderMode && (
-                          <IconButton
-                            size="small"
-                            sx={{
-                              position: "absolute",
-                              top: 8,
-                              right: 8,
-                              bgcolor: "background.paper",
-                              boxShadow: 1,
-                              pointerEvents: "none",
-                            }}
-                            aria-label={t("Reorder")}
-                          >
-                            <DragIndicatorIcon fontSize="small" />
-                          </IconButton>
-                        )}
-                        <Button
-                          variant="contained"
-                          onClick={() => handleExecute(scene.sceneId)}
-                          disabled={!isTokenValid || isExecuting || isReorderMode}
-                          sx={{
-                            position: "relative",
-                            height: 50,
-                            width: "100%",
-                            display: "flex",
-                            flexDirection: "column",
-                            alignItems: "center",
-                            justifyContent: "center",
-                            p: 1,
-                            borderRadius: 2,
-                            transition: "all 0.3s cubic-bezier(0.4, 0, 0.2, 1)",
-                            "&:hover:not(:disabled)": {
-                              transform: "translateY(-2px)",
-                              boxShadow: (theme) =>
-                                theme.palette.mode === "dark"
-                                  ? "0 4px 12px rgba(100, 181, 246, 0.25)"
-                                  : "0 4px 12px rgba(25, 118, 210, 0.25)",
-                            },
-                          }}
-                        >
-                          {isExecuting ? (
-                            <>
-                              <CircularProgress size={16} sx={{ color: "inherit", mb: 0.5 }} />
-                              <Typography variant="caption" sx={{ fontSize: "0.7rem" }}>
-                                {t("Executing...")}
-                              </Typography>
-                            </>
-                          ) : (
-                            <Typography
-                              variant="body2"
-                              fontWeight={600}
-                              noWrap
-                              sx={{
-                                textAlign: "center",
-                                width: "100%",
-                                px: 0.5,
-                                fontSize: "0.85rem",
-                              }}
-                            >
-                              {scene.sceneName || t("Unnamed Scene")}
-                            </Typography>
-                          )}
-                          {sceneError && (
-                            <Typography
-                              variant="caption"
-                              color="error"
-                              sx={{
-                                position: "absolute",
-                                bottom: 8,
-                                left: 0,
-                                right: 0,
-                                textAlign: "center",
-                                px: 1,
-                              }}
-                            >
-                              Error
-                            </Typography>
-                          )}
-                        </Button>
-                      </Box>
-                    </motion.div>
-                  );
-                })}
-              </AnimatePresence>
-            </Box>
+              <SortableContext items={sortableItems.map((scene) => scene.sceneId)} strategy={rectSortingStrategy}>
+                <Box
+                  sx={{
+                    display: "grid",
+                    gridTemplateColumns: "repeat(auto-fill, 160px)",
+                    gap: 1.5,
+                    justifyContent: "center",
+                  }}
+                >
+                  <AnimatePresence>
+                    {sortableItems.map((scene) => {
+                      const isExecuting = !!executingById[scene.sceneId];
+                      const sceneError = executionErrorById[scene.sceneId];
+                      return (
+                        <motion.div key={scene.sceneId} variants={itemVariants} layout>
+                          <SortableSceneButton
+                            scene={scene}
+                            isExecuting={isExecuting}
+                            sceneError={sceneError}
+                            isTokenValid={isTokenValid}
+                            isReorderMode={isReorderMode}
+                            isDragging={draggingId === scene.sceneId}
+                            isOver={dragOverId === scene.sceneId}
+                            onExecute={handleExecute}
+                            translationDisabled={!isReorderMode}
+                            label={t("Executing...")}
+                            unnamedLabel={t("Unnamed Scene")}
+                          />
+                        </motion.div>
+                      );
+                    })}
+                  </AnimatePresence>
+                </Box>
+              </SortableContext>
+            </DndContext>
           </motion.div>
         </>
       )}
@@ -430,5 +359,135 @@ export const ScenesScreen: React.FC = () => {
         </Alert>
       </Snackbar>
     </Container>
+  );
+};
+
+const SortableSceneButton: React.FC<{
+  scene: SceneSummary;
+  isExecuting: boolean;
+  sceneError?: string;
+  isTokenValid: boolean;
+  isReorderMode: boolean;
+  isDragging: boolean;
+  isOver: boolean;
+  translationDisabled: boolean;
+  onExecute: (sceneId: string) => void;
+  label: string;
+  unnamedLabel: string;
+}> = ({
+  scene,
+  isExecuting,
+  sceneError,
+  isTokenValid,
+  isReorderMode,
+  isDragging,
+  isOver,
+  translationDisabled,
+  onExecute,
+  label,
+  unnamedLabel,
+}) => {
+  const { attributes, listeners, setNodeRef, transform, transition, isSorting } = useSortable({ id: scene.sceneId });
+
+  const style = {
+    transform: translationDisabled ? undefined : CSS.Transform.toString(transform),
+    transition: translationDisabled ? undefined : transition,
+  };
+
+  return (
+    <Box ref={setNodeRef} style={style} {...(isReorderMode ? { ...attributes, ...listeners } : {})}>
+      <Box
+        sx={{
+          position: "relative",
+          opacity: isDragging || isSorting ? 0.5 : 1,
+          transition: "opacity 0.2s ease",
+          outline: isOver ? "2px solid" : "none",
+          outlineColor: "primary.main",
+          outlineOffset: "2px",
+          borderRadius: 2,
+          cursor: isReorderMode ? "grab" : "default",
+        }}
+      >
+        {isReorderMode && (
+          <IconButton
+            size="small"
+            sx={{
+              position: "absolute",
+              top: 8,
+              right: 8,
+              bgcolor: "background.paper",
+              boxShadow: 1,
+              pointerEvents: "none",
+            }}
+            aria-label="並び替え"
+          >
+            <DragIndicatorIcon fontSize="small" />
+          </IconButton>
+        )}
+        <Button
+          variant="contained"
+          onClick={() => onExecute(scene.sceneId)}
+          disabled={!isTokenValid || isExecuting || isReorderMode}
+          sx={{
+            position: "relative",
+            height: 50,
+            width: "100%",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            p: 1,
+            borderRadius: 2,
+            transition: "all 0.3s cubic-bezier(0.4, 0, 0.2, 1)",
+            "&:hover:not(:disabled)": {
+              transform: "translateY(-2px)",
+              boxShadow: (theme) =>
+                theme.palette.mode === "dark"
+                  ? "0 4px 12px rgba(100, 181, 246, 0.25)"
+                  : "0 4px 12px rgba(25, 118, 210, 0.25)",
+            },
+          }}
+        >
+          {isExecuting ? (
+            <>
+              <CircularProgress size={16} sx={{ color: "inherit", mb: 0.5 }} />
+              <Typography variant="caption" sx={{ fontSize: "0.7rem" }}>
+                {label}
+              </Typography>
+            </>
+          ) : (
+            <Typography
+              variant="body2"
+              fontWeight={600}
+              noWrap
+              sx={{
+                textAlign: "center",
+                width: "100%",
+                px: 0.5,
+                fontSize: "0.85rem",
+              }}
+            >
+              {scene.sceneName || unnamedLabel}
+            </Typography>
+          )}
+          {sceneError && (
+            <Typography
+              variant="caption"
+              color="error"
+              sx={{
+                position: "absolute",
+                bottom: 8,
+                left: 0,
+                right: 0,
+                textAlign: "center",
+                px: 1,
+              }}
+            >
+              Error
+            </Typography>
+          )}
+        </Button>
+      </Box>
+    </Box>
   );
 };


### PR DESCRIPTION
## Summary
- replace custom drag-and-drop handling for device and scene lists with dnd-kit sortable contexts while preserving existing UI behavior
- keep wheel scrolling active during drag so longer lists can be reordered while scrolling

## Testing
- not run (npm install blocked by registry access restrictions)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692737d68d7c832a8d32f923ec9c20d3)