### PR TITLE
Add dnd-kit sorting with wheel scrolling support

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,9 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^8.0.1",
+    "@dnd-kit/utilities": "^3.2.2",
     "@mui/icons-material": "^7.3.5",
     "@mui/material": "^7.1.1",
     "@reduxjs/toolkit": "^2.8.2",


### PR DESCRIPTION
## Summary
- add dnd-kit dependencies for sortable drag-and-drop handling
- migrate device and scene reorder interactions to dnd-kit while keeping existing behaviors
- ensure mouse wheel scrolling remains available during drag operations

## Testing
- Not run (npm install failed in container due to 403 from registry)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692737d68d7c832a8d32f923ec9c20d3)