### PR TITLE
Add support for IP65 Outdoor Thermo-Hygrometer (WoIOSensor) in overview

### DIFF
--- a/src/renderer/src/deviceDefinitions.ts
+++ b/src/renderer/src/deviceDefinitions.ts
@@ -751,18 +751,7 @@ const definitions: DeviceDefinition[] = [
   },
   {
     key: "meter",
-    matchers: [
-      "meter plus",
-      "meter pro co2",
-      "meter pro",
-      "outdoor meter",
-      "meter",
-      "WoIOSensor",        // ← dein IP65 Thermo-Hygrometer
-      "woiosensor",
-      "io sensor",
-      "outdoor thermo",
-      "ip65"
-    ],
+    matchers: ["meter plus", "meter pro co2", "meter pro", "outdoor meter", "meter", "WoIOSensor", "woiosensor"],
     statusFields: [
       ...tempHumidityFields,
       {

--- a/src/renderer/src/deviceDefinitions.ts
+++ b/src/renderer/src/deviceDefinitions.ts
@@ -751,7 +751,7 @@ const definitions: DeviceDefinition[] = [
   },
   {
     key: "meter",
-    matchers: ["meter plus", "meter pro co2", "meter pro", "outdoor meter", "meter", "WoIOSensor", "woiosensor"],
+    matchers: ["meter plus", "meter pro co2", "meter pro", "outdoor meter", "meter", "woiosensor"],
     statusFields: [
       ...tempHumidityFields,
       {

--- a/src/renderer/src/deviceDefinitions.ts
+++ b/src/renderer/src/deviceDefinitions.ts
@@ -751,7 +751,18 @@ const definitions: DeviceDefinition[] = [
   },
   {
     key: "meter",
-    matchers: ["meter plus", "meter pro co2", "meter pro", "outdoor meter", "meter"],
+    matchers: [
+      "meter plus",
+      "meter pro co2",
+      "meter pro",
+      "outdoor meter",
+      "meter",
+      "WoIOSensor",        // ← dein IP65 Thermo-Hygrometer
+      "woiosensor",
+      "io sensor",
+      "outdoor thermo",
+      "ip65"
+    ],
     statusFields: [
       ...tempHumidityFields,
       {
@@ -759,6 +770,8 @@ const definitions: DeviceDefinition[] = [
         label: "CO2",
         formatter: (value) => (value === undefined || value === null ? undefined : `${value} ppm`),
       },
+    ],
+  },
     ],
   },
   {

--- a/src/renderer/src/deviceDefinitions.ts
+++ b/src/renderer/src/deviceDefinitions.ts
@@ -761,8 +761,6 @@ const definitions: DeviceDefinition[] = [
       },
     ],
   },
-    ],
-  },
   {
     key: "hub2",
     matchers: ["hub 2"],


### PR DESCRIPTION
Hi @0suu,

I added support for the SwitchBot IP65 Thermo-Hygrometer (`WoIOSensor`) so that temperature and humidity are now displayed directly in the Devices overview — exactly like the normal Meter / Meter Plus.

**Change made in `deviceDefinitions.ts`:**

```ts
{
  key: "meter",
  matchers: [
    "meter plus",
    "meter pro co2",
    "meter pro",
    "outdoor meter",
    "meter",
    "WoIOSensor",      // ← added
    "woiosensor"
  ],
  statusFields: [
    ...tempHumidityFields,
    // CO2 field stays the same
  ],
},